### PR TITLE
Check if no project name is present.

### DIFF
--- a/lambo
+++ b/lambo
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+#### Check for project name argument.
+if [ $# -eq 0 ]
+  then
+    echo "Please supply a project name."
+    exit 1
+fi
+
 ## Error handling
 abort()
 {


### PR DESCRIPTION
Running "lambo" with no arguments (project name) wreaks all sorts of havoc.

I ran "lambo" like I would "valet" or "laravel" to see the list of commands and a description and nuked the project that was my current working directory.

Ideally we would set this up using something like: [mnapoli/silly](https://github.com/mnapoli/silly), but I figured this would be an "MVP" version of the feature.

Just throwing this out there, if it's worth it I would be happy to give "mnapoli/silly" a shot to provide a more elegant interface.