### PR TITLE
Add feature to set path and commit message

### DIFF
--- a/lambo
+++ b/lambo
@@ -18,11 +18,35 @@ set -e
 ## Start script
 
 PROJECTNAME=$1
+PROJECTPATH="."
+MESSAGE="Initial commit."
+
+while [[ $# -gt 1 ]]
+do
+    key="$1"
+
+    case $key in
+        -p|--path)
+            PROJECTPATH="$2"
+            shift
+            ;;
+        -m|--message)
+            MESSAGE="$2"
+            shift
+            ;;
+        *)
+            ;;
+    esac
+
+    shift
+done
+
+cd $PROJECTPATH
 laravel new $PROJECTNAME
 cd $PROJECTNAME
 git init
 git add .
-git commit -m "Initial commit."
+git commit -m "$MESSAGE"
 open "http://$PROJECTNAME.dev"
 echo "***********************"
 echo "You're ready to go! Remember to cd into $PROJECTNAME before you start editing."

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,24 @@ composer global require tightenco/lambo
 Make sure `~/.composer/vendor/bin` is in your terminal's path.
 
 ```bash
-cd ~/Sites
 lambo superApplication
 ```
 
 This will `laravel new superApplication`, change into that directory, make an initial Git commit, and open your web browser to that app.
+
+### Arguments
+
+- `-p` or `--path` to specify where to install the application.
+
+  ```bash
+  lambo superApplication -p ~/Sites
+  ```
+
+- `-m` or `--message` to set the first commit message.
+
+  ```bash
+  lambo superApplication -m "This lambo runs fast!"
+  ```
 
 ## Requirements
 


### PR DESCRIPTION
With argument -p or --path can specify the base path where create the
application. Current path by default.

With argument -m or --message can specify the first commit message. "Initial
commit." by default.