### PR TITLE
[bugfix] Remove `shift` for options without arguments.

### DIFF
--- a/lambo
+++ b/lambo
@@ -85,11 +85,9 @@ do
             ;;
         -d|--develop|--dev)
             DEVELOP=true
-            shift
             ;;
         -a|--auth)
             AUTH=true
-            shift
             ;;
         *)
             ;;


### PR DESCRIPTION
By using `shift` in a `while` loop with options that have no arguments (ie: -d  -a) it is possible for Lambo to skip an option. Example:
```bash
lambo project-name -a -d -e atom
```
This would run only --auth and --editor options and skip the --develop option.