### PR TITLE
Changed .env replacements to use perl instead of sed

### DIFF
--- a/lambo
+++ b/lambo
@@ -139,22 +139,20 @@ fi
 # Update .env to point to this database with `root` username and blank pw,
 # like Mac MySQL defaults, and appropriate domain
 PROJECTURL="http://$PROJECTNAME.$TLD"
-sedCommands=(
-    "/DB_DATABASE/s/homestead/$PROJECTNAME/"
-    '/DB_USERNAME/s/homestead/root/'
-    '/DB_PASSWORD/s/secret//'
-    "/APP_URL/s/localhost/$PROJECTNAME\.$TLD/"
+perlCommands=(
+    "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
+    's/(DB_USERNAME=)(.*)/\1root/g'
+    's/(DB_PASSWORD=)(.*)/\1/g'
+    "s/(APP_URL=)(.*)/\1$PROJECTNAME\.$TLD/g"
 )
 
-if [[ "$(uname)" == "Darwin" ]]; then
-    for sedCommand in "${sedCommands[@]}"; do
-        sed -i '' "$sedCommand" .env
+for perlCommand in "${perlCommands[@]}"; do
+    perl -pi -e "$perlCommand" ".env"
     done
+
+if [[ "$(uname)" == "Darwin" ]]; then
     open "$PROJECTURL"
 elif [[ "$(expr substr $(uname -s) 1 5)" == "Linux" ]]; then
-    for sedCommand in "${sedCommands[@]}"; do
-        sed -i "$sedCommand" .env
-    done
     xdg-open "$PROJECTURL"
 fi
 


### PR DESCRIPTION
This replaces sed usage with perl -pie.

My macOS system has GNU sed so the Darwin check did not work for me. Rather than rewrite the sed checks, I simply replaced sed with perl as perl just works.

It might require tweaking as I'm not an expert here, but I did test this `lambo` on macOS and the .env replacement code on Ubuntu.

In addition, it changes the current values and does not assume the current defaults (e.g., homestead, secret, localhost) in case those change or if lambo is executed on an existing project. This is a BC break that could be removed, if needed, as it might offer unattended consequences. 