### PR TITLE
create mysql database with new project

### DIFF
--- a/lambo
+++ b/lambo
@@ -69,7 +69,9 @@ AUTH=false
 NODE=false
 CODEEDITOR=""
 BROWSER=""
-LINK=false' > ~/.lambo/config
+LINK=false
+MYSQL_USERNAME="homestead"
+MYSQL_PASSWORD="secret"' > ~/.lambo/config
 
     edit ~/.lambo/config
 }
@@ -160,6 +162,7 @@ CODEEDITOR=""
 BROWSER=""
 TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 LINK=false
+MYSQL_USERNAME="root"
 
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
@@ -225,6 +228,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         -n|--node)
             NODE=true
+            ;;
+        -m|--mysql)
+            MYSQL=true
             ;;
         -l|--link)
             LINK=true
@@ -293,6 +299,14 @@ fi
 git init
 git add .
 git commit -m "$MESSAGE"
+
+if [[ "$MYSQL" = true ]]; then
+	if [[ "$MYSQL_PASSWORD" = true ]]; then
+		echo "CREATE DATABASE "$PROJECTNAME | mysql -u $MYSQL_USERNAME -p $MYSQL_PASSWORD
+	else
+		echo "CREATE DATABASE "$PROJECTNAME | mysql -u $MYSQL_USERNAME
+	fi
+fi
 
 # Update .env to point to this database with `root` username and blank pw,
 # like Mac MySQL defaults, and appropriate domain

--- a/lambo
+++ b/lambo
@@ -302,9 +302,9 @@ git commit -m "$MESSAGE"
 
 if [[ "$MYSQL" = true ]]; then
 	if [[ "$MYSQL_PASSWORD" = true ]]; then
-		echo "CREATE DATABASE "$PROJECTNAME | mysql -u $MYSQL_USERNAME -p $MYSQL_PASSWORD
+		echo "CREATE DATABASE IF NOT EXISTS "$PROJECTNAME | mysql -u $MYSQL_USERNAME -p $MYSQL_PASSWORD
 	else
-		echo "CREATE DATABASE "$PROJECTNAME | mysql -u $MYSQL_USERNAME
+		echo "CREATE DATABASE IF NOT EXISTS "$PROJECTNAME | mysql -u $MYSQL_USERNAME
 	fi
 fi
 


### PR DESCRIPTION
Now that a config file has been introduced where database credentials can be stored, we can create the necessary database whenever creating a project. Currently it only works with MySQL. To use, pass `--mysql` or `-m` flags to the script. 

A few concerns:
Defaults: Currently if no username or password is present in the config file, we use 
Valet defaults (username root, no pw). The default config file has credentials for Homestead (username homestead, pw secret). Should the two default options be uniform? Is it preferable to work out of the box with Valet or Homestead?

Security: Obviously we're storing database credentials in a file without any protection. I don't consider that to be a problem since this tool is built for dev environments but am happy to discuss any other opinions.