### PR TITLE
Create .env file from .env.example

### DIFF
--- a/lambo
+++ b/lambo
@@ -308,6 +308,9 @@ git commit -m "$MESSAGE"
 
 # Update .env to point to this database with `root` username and blank pw,
 # like Mac MySQL defaults, and appropriate domain
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
 PROJECTURL="http://$PROJECTNAME.$TLD"
 sedCommands=(
     "/DB_DATABASE/s/homestead/$PROJECTNAME/"


### PR DESCRIPTION
By default the `.env` file is not present on fresh larval installation; copying `.env.example` to `.env`