### PR TITLE
Add Presets Option

### DIFF
--- a/lambo
+++ b/lambo
@@ -21,23 +21,23 @@ showhelp()
     echo " "
     echo "${orange}Commands (lambo COMMANDNAME):"
     echo " "
-    echo "${green}   make-config${reset}                  Generate config file"
-    echo "${green}   edit-config${reset}                  Edit config file"
+    echo "${green}   make-config${reset}                    Generate config file"
+    echo "${green}   edit-config${reset}                    Edit config file"
     echo " "
-    echo "${green}   make-after${reset}                   Generate after file"
-    echo "${green}   edit-after${reset}                   Edit after file"
+    echo "${green}   make-after${reset}                     Generate after file"
+    echo "${green}   edit-after${reset}                     Edit after file"
     echo " "
     echo "${orange}Options (lambo myApplication OPTIONS):"
-    echo "${green}  -h, --help${reset}                    Show brief help"
-    echo "${green}  -e, --editor EDITOR${reset}           Specify an editor to run '${green}EDITOR .${reset}' with after"
-    echo "${green}  -m, --message \"message\"${reset}       Customize the initial commit message"
-    echo "${green}  -p, --path PATH${reset}               Customize the path in which the new project will be created"
-    echo "${green}  -d, --dev${reset}                     Use Composer to install on the develop branch"
-    echo "${green}  -a, --auth${reset}                    Use Artisan to scaffold all of the routes and views you need for authentication"
-    echo "${green}  -n, --node${reset}                    Runs '${green}yarn${reset}' if installed, otherwise runs '${green}npm install${reset}' after creating the project"
-    echo "${green}  -b, --browser \"browser path\"${reset}  Opens site in specified browser"
-    echo "${green}  -l, --link${reset}                    Creates a Valet link to the project directory"
-    echo "${green}  -s, --preset \"preset\"${reset}       Run a set of preset commands"
+    echo "${green}  -h, --help${reset}                      Show brief help"
+    echo "${green}  -e, --editor EDITOR${reset}             Specify an editor to run '${green}EDITOR .${reset}' with after"
+    echo "${green}  -m, --message \"message\"${reset}         Customize the initial commit message"
+    echo "${green}  -p, --path PATH${reset}                 Customize the path in which the new project will be created"
+    echo "${green}  -d, --dev${reset}                       Use Composer to install on the develop branch"
+    echo "${green}  -a, --auth${reset}                      Use Artisan to scaffold all of the routes and views you need for authentication"
+    echo "${green}  -n, --node${reset}                      Runs '${green}yarn${reset}' if installed, otherwise runs '${green}npm install${reset}' after creating the project"
+    echo "${green}  -b, --browser \"browser path\"${reset}    Opens site in specified browser"
+    echo "${green}  -l, --link${reset}                      Creates a Valet link to the project directory"
+    echo "${green}  -r, --recipes \"recipe1,recipe2\"${reset} Run a set of recipe files"
     quit
 }
 
@@ -171,7 +171,7 @@ CODEEDITOR=""
 BROWSER=""
 TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 LINK=false
-PRESETS=""
+RECIPES=""
 
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
@@ -241,8 +241,8 @@ while [[ $# -gt 0 ]]; do
         -l|--link)
             LINK=true
             ;;
-        -s|--presets)
-            PRESETS="$2"
+        -r|--recipes)
+            RECIPES="$2"
             ;;
         *)
             ;;
@@ -356,14 +356,14 @@ if [[ -f ~/.lambo/after ]]; then
 fi
 
 ### Load preset files if they exist
-IFS=',' read -ra PRESETS <<< "$PRESETS"
+IFS=',' read -ra RECIPES <<< "$RECIPES"
 
-for PRESET in "${PRESETS[@]}"; do
-    if [[ -f ~/.lambo/presets/$PRESET.sh ]]; then
-        echo "${green}Running $PRESET Preset...${reset}"
-        source "$HOME/.lambo/presets/$PRESET.sh"
+for RECIPE in "${RECIPES[@]}"; do
+    if [[ -f ~/.lambo/recipes/$RECIPE.sh ]]; then
+        echo "${green}Running $RECIPE Recipe...${reset}"
+        source "$HOME/.lambo/recipes/$RECIPE.sh"
     else
-        echo "${red}Preset $PRESET not found. ${reset}"
+        echo "${red}Recipe $RECIPE not found. ${reset}"
     fi
 done
 

--- a/lambo
+++ b/lambo
@@ -37,6 +37,7 @@ showhelp()
     echo "${green}  -n, --node${reset}                    Runs '${green}yarn${reset}' if installed, otherwise runs '${green}npm install${reset}' after creating the project"
     echo "${green}  -b, --browser \"browser path\"${reset}  Opens site in specified browser"
     echo "${green}  -l, --link${reset}                    Creates a Valet link to the project directory"
+    echo "${green}  -s, --preset \"preset\"${reset}       Run a set of preset commands"
     quit
 }
 
@@ -170,6 +171,7 @@ CODEEDITOR=""
 BROWSER=""
 TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 LINK=false
+PRESETS=""
 
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
@@ -238,6 +240,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         -l|--link)
             LINK=true
+            ;;
+        -s|--presets)
+            PRESETS="$2"
             ;;
         *)
             ;;
@@ -349,6 +354,18 @@ if [[ -f ~/.lambo/after ]]; then
     echo "${green}Running additional commands...${reset}"
     source ~/.lambo/after
 fi
+
+### Load preset files if they exist
+IFS=',' read -ra PRESETS <<< "$PRESETS"
+
+for PRESET in "${PRESETS[@]}"; do
+    if [[ -f ~/.lambo/presets/$PRESET.sh ]]; then
+        echo "${green}Running $PRESET Preset...${reset}"
+        source "$HOME/.lambo/presets/$PRESET.sh"
+    else
+        echo "${red}Preset $PRESET not found. ${reset}"
+    fi
+done
 
 if [[ "$CODEEDITOR" != "" ]]; then
     if isterminaleditor; then

--- a/lambo
+++ b/lambo
@@ -272,6 +272,16 @@ if ! hash git 2>/dev/null; then
   quit
 fi
 
+### Check if preset files exist
+IFS=',' read -ra RECIPES <<< "$RECIPES"
+
+for RECIPE in "${RECIPES[@]}"; do
+    if [[ ! -f ~/.lambo/recipes/$RECIPE.sh ]]; then
+        echo "${red}Recipe $RECIPE not found. ${reset}"
+        abort;
+    fi
+done
+
 cd "$PROJECTPATH" || exit
 
 echo "
@@ -355,16 +365,10 @@ if [[ -f ~/.lambo/after ]]; then
     source ~/.lambo/after
 fi
 
-### Load preset files if they exist
-IFS=',' read -ra RECIPES <<< "$RECIPES"
-
+### Load recipe files
 for RECIPE in "${RECIPES[@]}"; do
-    if [[ -f ~/.lambo/recipes/$RECIPE.sh ]]; then
-        echo "${green}Running $RECIPE Recipe...${reset}"
-        source "$HOME/.lambo/recipes/$RECIPE.sh"
-    else
-        echo "${red}Recipe $RECIPE not found. ${reset}"
-    fi
+    echo "${green}Running $RECIPE Recipe...${reset}"
+    source "$HOME/.lambo/recipes/$RECIPE.sh"
 done
 
 if [[ "$CODEEDITOR" != "" ]]; then

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,14 @@ There are also a few optional behaviors based on the parameters you pass (or def
   lambo superApplication --link
   ```
 
+- `-s` or `--presets` to provide a list of presets files to run located in ~/.lambo/presets/.
+
+  ```bash
+  lambo superApplication --presets "API"
+  or
+  lambo superApplication --presets "base,API"
+  ```
+
 ### Commands
 
 - `make-config` creates a config file so you don't have to pass the parameters every time you use Lambo


### PR DESCRIPTION
Add option to pass either a single or list of presets separated by a comma. 
`lambo superApplication --presets "base"` or `lambo superApplication --presets "base,API"`

This will look for a file called `~/.lambo/presets/PRESET.sh` and run it if it exists, or display a warning if it does not exist. 

In this gif you can see the output with the preset existing 'base', in this case just an echo statement, and a preset not existing 'API'.
![lambopresets](https://user-images.githubusercontent.com/1762128/31630719-52d235e8-b26c-11e7-978c-ed5184ffb6e9.gif)
