### PR TITLE
Update laravel/installer requirement to >=1.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "laravel/installer": ">=1.3.1"
+        "laravel/installer": ">=1.4.1"
     },
     "bin": [
         "lambo"


### PR DESCRIPTION
laravel/installer 1.4.1 removes post-install-cmd that was removed from
laravel 5.5.

See issue #45.