### PR TITLE
Lambo Option - Link (HTTPS Support)

### DIFF
--- a/lambo
+++ b/lambo
@@ -320,7 +320,7 @@ perlCommands=(
 )
 
 if [[ "$LINK" = true ]]; then
-    if [[ "$TLD" == 'dev' ]]; then
+    if [[ "$TLD" == 'dev' || "$TLD" == 'foo' ]]; then
         valet secure "$PROJECTNAME"
     fi
     valet link "$PROJECTNAME"

--- a/lambo
+++ b/lambo
@@ -320,7 +320,9 @@ perlCommands=(
 )
 
 if [[ "$LINK" = true ]]; then
-    valet secure "$PROJECTNAME"
+    if [[ "$TLD" == 'dev' ]]; then
+        valet secure "$PROJECTNAME"
+    fi
     valet link "$PROJECTNAME"
 fi
 

--- a/lambo
+++ b/lambo
@@ -36,7 +36,7 @@ showhelp()
     echo "${green}  -a, --auth${reset}                    Use Artisan to scaffold all of the routes and views you need for authentication"
     echo "${green}  -n, --node${reset}                    Runs '${green}yarn${reset}' if installed, otherwise runs '${green}npm install${reset}' after creating the project"
     echo "${green}  -b, --browser \"browser path\"${reset}  Opens site in specified browser"
-    echo "${green}  -l, --link${reset}                    Creates a Valet link to the project directory"
+    echo "${green}  -l, --link${reset}                    Creates a Valet secure link to the project directory"
     quit
 }
 
@@ -320,6 +320,7 @@ perlCommands=(
 )
 
 if [[ "$LINK" = true ]]; then
+    valet secure "$PROJECTNAME"
     valet link "$PROJECTNAME"
 fi
 


### PR DESCRIPTION
From my understanding, the HSTS Preload List now requires browsers to server both `.dev` and `.foo` over HTTPS. Currently I have to run `valet secure` in the project directory, after running `lambo appName --link`, because my Valet domain is set to `.dev`.

I added a conditional to test if the `$TLD` is set to either `.dev` or `.foo`, and if either are true the `valet secure` command will run before the `valet link` command. The commands are ran in that order because Valet needs to restart both PHP and nginx.

BTW this is the first time I've ever submitted a pull request, so I hope I've done it correctly. Hope these changes help, and please let me know how I can improve when submitting pull requests.

Thank you.