### PR TITLE
Having DB credentials in config file + Creating database optionally, by flag in config

### DIFF
--- a/lambo
+++ b/lambo
@@ -80,7 +80,7 @@ BROWSER=""
 LINK=false
 CREATEDATABASE=false
 DBUSER=root
-BDPASSWORD=' > ~/.lambo/config
+DBPASSWORD=' > ~/.lambo/config
 
     edit ~/.lambo/config
 }
@@ -158,7 +158,7 @@ quit()
 
 createdatabase()
 {
-    mysql --user=$DBUSER --password=$BDPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
+    mysql --user=$DBUSER --password=$DBPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
 }
 
 
@@ -179,7 +179,7 @@ TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->d
 LINK=false
 CREATEDATABASE=false
 DBUSER=root
-BDPASSWORD=
+DBPASSWORD=
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
     source ~/.lambo/config
@@ -324,7 +324,7 @@ PROJECTURL="http://$PROJECTNAME.$TLD"
 perlCommands=(
     "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
     "s/(DB_USERNAME=)(.*)/\1$DBUSER/g"
-    "s/(DB_PASSWORD=)(.*)/\1$BDPASSWORD/g"
+    "s/(DB_PASSWORD=)(.*)/\1$DBPASSWORD/g"
     "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"
 )
 

--- a/lambo
+++ b/lambo
@@ -77,7 +77,10 @@ AUTH=false
 NODE=false
 CODEEDITOR=""
 BROWSER=""
-LINK=false' > ~/.lambo/config
+LINK=false
+CREATEDATABASE=false
+DBUSER=root
+BDPASSWORD=' > ~/.lambo/config
 
     edit ~/.lambo/config
 }
@@ -153,6 +156,10 @@ quit()
     exit 0
 }
 
+createdatabase()
+{
+    mysql --user=$DBUSER --password=$BDPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
+}
 
 
 ## Set up error handling
@@ -170,7 +177,9 @@ CODEEDITOR=""
 BROWSER=""
 TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 LINK=false
-
+CREATEDATABASE=false
+DBUSER=root
+BDPASSWORD=
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
     source ~/.lambo/config
@@ -314,8 +323,8 @@ fi
 PROJECTURL="http://$PROJECTNAME.$TLD"
 perlCommands=(
     "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
-    's/(DB_USERNAME=)(.*)/\1root/g'
-    's/(DB_PASSWORD=)(.*)/\1/g'
+    "s/(DB_USERNAME=)(.*)/\1$DBUSER/g"
+    "s/(DB_PASSWORD=)(.*)/\1$BDPASSWORD/g"
     "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"
 )
 
@@ -341,6 +350,13 @@ case $PROJECTPATH in
  ".") prettyPath="$PROJECTNAME" ;;
  *) prettyPath="$PROJECTPATH/$PROJECTNAME" ;;
 esac
+
+### Create database if config is set to true
+if [[ "$CREATEDATABASE" = true ]]; then
+    echo "${green}Creating database...${reset}"
+    createdatabase
+fi
+
 
 ### Load after file if it exists
 if [[ -f ~/.lambo/after ]]; then


### PR DESCRIPTION
Hello Tighten! Great superpower 😃 

- Added bonus cool time saver, is to create the database (optionally by flag on config, defaults to false, as is)

- Also, more flexibility if DB credentials are in config file.
I also use Valet, but sometimes have to use Homestead, keeping the MySQL on the host MacOS.
So, when connecting from Homestead, the root user's password can't be blank.
For example, root/root, nice to be able to customize

I know the warning about using a password in the command line, but is it really an issue, when it's a local environment with such easy defaults?

Changes in the PR:

1 - On the generation of config file, added key-values:
~~~
CREATEDATABASE=false
DBUSER=root
BDPASSWORD=
~~~

2 - Starting the Lambo with same defaults
~~~
CREATEDATABASE=false
DBUSER=root
BDPASSWORD=
~~~

3 - The filling of credentials for .env file is based on the defaults or configuration override

4 - Added function to generate database 
~~~
createdatabase()
{
    mysql --user=$DBUSER --password=$BDPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
}
~~~

5 - Actually create it, based on config flag
~~~
if [[ "$CREATEDATABASE" = true ]]; then
    echo "${green}Creating database...${reset}"
    createdatabase
fi
~~~