### PR TITLE
Update reference to tld in valet config.json

### DIFF
--- a/lambo
+++ b/lambo
@@ -175,9 +175,9 @@ NODE=false
 CODEEDITOR=""
 BROWSER=""
 if [[ -f ~/.config/valet/config.json ]]; then
-    TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.config/valet/config.json'))->domain;")
+    TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.config/valet/config.json'))->tld;")
 else
-    TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
+    TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->tld;")
 fi
 LINK=false
 


### PR DESCRIPTION
Laravel Valet changed domain to tld in the config.json #62 

Lambo is still looking for the domain configuration value which results in an error.