### PR TITLE
Add secure flag (#60) to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,12 @@ There are also a few optional behaviors based on the parameters you pass (or def
   lambo superApplication --link
   ```
 
+- `-s` or `--secure` to secure the Valet site using https.
+
+  ```bash
+  lambo superApplication --secure
+  ```
+
 ### Commands
 
 - `make-config` creates a config file so you don't have to pass the parameters every time you use Lambo


### PR DESCRIPTION
This PR adds documentation for the `-s`/`--secure` flag added in #60.