### PR TITLE
Fix perl regex to use named backreferences

### DIFF
--- a/lambo
+++ b/lambo
@@ -344,10 +344,10 @@ if [ ! -f .env ]; then
 fi
 PROJECTURL="http://$PROJECTNAME.$TLD"
 perlCommands=(
-    "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
-    "s/(DB_USERNAME=)(.*)/\1$DB_USERNAME/g"
-    "s/(DB_PASSWORD=)(.*)/\1$DB_PASSWORD/g"
-    "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"
+    "s/(?'var'DB_DATABASE=)(.*)/$+{var}$PROJECTNAME/g"
+    "s/(?'var'DB_USERNAME=)(.*)/$+{var}$DB_USERNAME/g"
+    "s/(?'var'DB_PASSWORD=)(.*)/$+{var}$DB_PASSWORD/g"
+    "s/(?'var'APP_URL=)(.*)/$+{var}http:\/\/$PROJECTNAME.$TLD/g"
 )
 
 for perlCommand in "${perlCommands[@]}"; do


### PR DESCRIPTION
If you create a project that starts with a number, `DB_DATABASE` is lost in the updated `.env` file. This is because original regex uses `\1` numbered backreference. When project starts with a number, the first digit of the project name is joined with `1` to point to unknown backreference.

For example, if the project name is `9cloud`, the  `\19cloud` - points to the 19th matching group which does not exist.

To fix this, I used [named backreferences](https://www.regular-expressions.info/replacebackref.html#named).