### PR TITLE
Add support for BROWSER=false

### DIFF
--- a/lambo
+++ b/lambo
@@ -413,10 +413,14 @@ fi
 
 ### Open the browser
 if [[ "$(uname)" == "Darwin" ]]; then
-    if [[ "$BROWSER" != "" ]]; then
-        open -a "$BROWSER" "$PROJECTURL"
+    if [[ "$BROWSER" = false ]]; then
+        shift
     else
-        open "$PROJECTURL"
+        if [[ "$BROWSER" != "" ]]; then
+            open -a "$BROWSER" "$PROJECTURL"
+        else
+            open "$PROJECTURL"
+        fi
     fi
 elif [[ "$(expr substr $(uname -s) 1 5)" == "Linux" ]]; then
     xdg-open "$PROJECTURL"


### PR DESCRIPTION
Add to support to not open a browser after initial creation of the application when config option BROWSER is set to false.