### PR TITLE
add option to create a new database for the project

### DIFF
--- a/lambo
+++ b/lambo
@@ -177,7 +177,7 @@ ui_package_exists() {
 
 createdatabase()
 {
-    mysql --user=$DBUSER --password=$BDPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
+    mysql --user=$DBUSER --password=$DBPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
 }
 
 
@@ -206,7 +206,7 @@ fi
 LINK=false
 CREATEDATABASE=false
 DBUSER=root
-BDPASSWORD=
+DBPASSWORD=
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
     source ~/.lambo/config
@@ -407,7 +407,7 @@ PROJECTURL="http://$PROJECTNAME.$TLD"
 perlCommands=(
     "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
     "s/(DB_USERNAME=)(.*)/\1$DBUSER/g"
-    "s/(DB_PASSWORD=)(.*)/\1$BDPASSWORD/g"
+    "s/(DB_PASSWORD=)(.*)/\1$DBPASSWORD/g"
     "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"
 )
 

--- a/lambo
+++ b/lambo
@@ -175,6 +175,10 @@ ui_package_exists() {
     composer show | grep laravel/ui >/dev/null
 }
 
+createdatabase()
+{
+    mysql --user=$DBUSER --password=$BDPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
+}
 
 
 ## Set up error handling
@@ -200,7 +204,9 @@ else
     TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 fi
 LINK=false
-
+CREATEDATABASE=false
+DBUSER=root
+BDPASSWORD=
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
     source ~/.lambo/config
@@ -399,10 +405,10 @@ fi
 PROJECTURL="http://$PROJECTNAME.$TLD"
 
 perlCommands=(
-    "s/(?'var'DB_DATABASE=)(.*)/$+{var}$PROJECTNAME/g"
-    "s/(?'var'DB_USERNAME=)(.*)/$+{var}$DB_USERNAME/g"
-    "s/(?'var'DB_PASSWORD=)(.*)/$+{var}$DB_PASSWORD/g"
-    "s/(?'var'APP_URL=)(.*)/$+{var}http:\/\/$PROJECTNAME.$TLD/g"
+    "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
+    "s/(DB_USERNAME=)(.*)/\1$DBUSER/g"
+    "s/(DB_PASSWORD=)(.*)/\1$BDPASSWORD/g"
+    "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"
 )
 
 for perlCommand in "${perlCommands[@]}"; do
@@ -448,6 +454,12 @@ case $PROJECTPATH in
  ".") prettyPath="$PROJECTNAME" ;;
  *) prettyPath="$PROJECTPATH/$PROJECTNAME" ;;
 esac
+
+### Create database if config is set to true
+if [[ "$CREATEDATABASE" = true ]]; then
+    echo "${green}Creating database...${reset}"
+    createdatabase
+fi
 
 if [[ "$CODEEDITOR" != "" ]]; then
     if isterminaleditor; then

--- a/lambo
+++ b/lambo
@@ -12,9 +12,14 @@ TERMINAL_EDITORS=("vim" "vi" "nano" "pico" "ed" "emacs" "nvim")
 ## Init functions
 showhelp()
 {
-    echo " "
-    echo "${green}Lambo: Super-powered '${orange}laravel new${green}' for Laravel and Valet"
-    echo "${reset}________________________________________________________"
+    printf "${green}"
+    echo '    __                    __        
+   / /   ____ _____ ___  / /_  ____ 
+  / /   / __ `/ __ `__ \/ __ \/ __ \
+ / /___/ /_/ / / / / / / /_/ / /_/ /
+/_____/\__,_/_/ /_/ /_/_.___/\____/ 
+                                    '
+    echo "${green}Lambo:${reset} Super-powered '${orange}laravel new${reset}' for Laravel and Valet"
     echo " "
     echo "${orange}Usage:"
     echo "${reset}  lambo myApplication [arguments]"
@@ -39,11 +44,12 @@ showhelp()
     echo "${green}  -l, --link${reset}                    Creates a Valet link to the project directory"
     echo "${green}  -s, --secure${reset}                  Generate and use https with Valet"
     echo "${green}  -q, --quiet${reset}                   Use muffler (quiet mode)"
+    echo "${green}  --create-db${reset}                   Create a new MySql database"
     echo "${green}  --dbuser${reset}                      Specify the database user"
     echo "${green}  --dbpassword${reset}                  Specify the database password"
-    echo "${green}  --vue${reset}                          Specify Vue as the frontend"
-    echo "${green}  --bootstrap${reset}                    Specify Bootstrap as the frontend"
-    echo "${green}  --react${reset}                        Specify React as the frontend"
+    echo "${green}  --vue${reset}                         Specify Vue as the frontend"
+    echo "${green}  --bootstrap${reset}                   Specify Bootstrap as the frontend"
+    echo "${green}  --react${reset}                       Specify React as the frontend"
     quit
 }
 
@@ -88,6 +94,7 @@ BROWSER=""
 LINK=false
 SECURE=false
 FRONTEND="vue"
+CREATE_DATABASE=false
 DB_USERNAME="root"
 DB_PASSWORD=""' > ~/.lambo/config
 
@@ -171,13 +178,18 @@ quit()
     exit 0
 }
 
-ui_package_exists() {
+ui_package_exists()
+{
     composer show | grep laravel/ui >/dev/null
 }
 
 createdatabase()
 {
-    mysql --user=$DBUSER --password=$DBPASSWORD -e "CREATE DATABASE IF NOT EXISTS $DBNAME;"
+    if hash mysql 2>/dev/null; then
+        mysql --user=$DB_USERNAME --password=$DB_PASSWORD -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE;"
+    else
+        echo "${red}MySql is not installed. Skipping this step...${reset}"
+    fi
 }
 
 
@@ -196,6 +208,8 @@ NODE=false
 CODEEDITOR=""
 BROWSER=""
 FRONTEND="vue"
+DB_DATABASE="${PROJECTNAME//[-]/_}"
+CREATE_DATABASE=false
 DB_USERNAME="root"
 DB_PASSWORD=""
 if [[ -f ~/.config/valet/config.json ]]; then
@@ -204,10 +218,7 @@ else
     TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 fi
 LINK=false
-DBNAME="${PROJECTNAME//[-]/_}"
-CREATEDATABASE=false
-DBUSER=root
-DBPASSWORD=
+
 ### Load config if it exists
 if [[ -f ~/.lambo/config ]]; then
     source ~/.lambo/config
@@ -278,6 +289,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         -s|--secure)
             SECURE=true
+            ;;
+        --create-db)
+            CREATE_DATABASE=true
             ;;
         --dbuser)
             DB_USERNAME="$2"
@@ -406,10 +420,10 @@ fi
 PROJECTURL="http://$PROJECTNAME.$TLD"
 
 perlCommands=(
-    "s/(DB_DATABASE=)(.*)/\1$DBNAME/g"
-    "s/(DB_USERNAME=)(.*)/\1$DBUSER/g"
-    "s/(DB_PASSWORD=)(.*)/\1$DBPASSWORD/g"
-    "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"
+    "s/(?'var'DB_DATABASE=)(.*)/$+{var}$DB_DATABASE/g"
+    "s/(?'var'DB_USERNAME=)(.*)/$+{var}$DB_USERNAME/g"
+    "s/(?'var'DB_PASSWORD=)(.*)/$+{var}$DB_PASSWORD/g"
+    "s/(?'var'APP_URL=)(.*)/$+{var}http:\/\/$PROJECTNAME.$TLD/g"
 )
 
 for perlCommand in "${perlCommands[@]}"; do
@@ -430,6 +444,14 @@ fi
 
 if [[ "$SECURE" = true ]]; then
     valet secure "$PROJECTNAME"
+fi
+
+### Create database if config is set to true
+if [[ "$CREATE_DATABASE" = true ]]; then
+    echo "
+${green}Creating database...${reset}
+    "
+    createdatabase
 fi
 
 ### Load after file if it exists
@@ -455,12 +477,6 @@ case $PROJECTPATH in
  ".") prettyPath="$PROJECTNAME" ;;
  *) prettyPath="$PROJECTPATH/$PROJECTNAME" ;;
 esac
-
-### Create database if config is set to true
-if [[ "$CREATEDATABASE" = true ]]; then
-    echo "${green}Creating database...${reset}"
-    createdatabase
-fi
 
 if [[ "$CODEEDITOR" != "" ]]; then
     if isterminaleditor; then

--- a/lambo
+++ b/lambo
@@ -177,7 +177,7 @@ ui_package_exists() {
 
 createdatabase()
 {
-    mysql --user=$DBUSER --password=$DBPASSWORD -e "CREATE DATABASE IF NOT EXISTS $PROJECTNAME;"
+    mysql --user=$DBUSER --password=$DBPASSWORD -e "CREATE DATABASE IF NOT EXISTS $DBNAME;"
 }
 
 
@@ -204,6 +204,7 @@ else
     TLD=$(php -r "echo json_decode(file_get_contents('$HOME/.valet/config.json'))->domain;")
 fi
 LINK=false
+DBNAME="${PROJECTNAME//[-]/_}"
 CREATEDATABASE=false
 DBUSER=root
 DBPASSWORD=
@@ -405,7 +406,7 @@ fi
 PROJECTURL="http://$PROJECTNAME.$TLD"
 
 perlCommands=(
-    "s/(DB_DATABASE=)(.*)/\1$PROJECTNAME/g"
+    "s/(DB_DATABASE=)(.*)/\1$DBNAME/g"
     "s/(DB_USERNAME=)(.*)/\1$DBUSER/g"
     "s/(DB_PASSWORD=)(.*)/\1$DBPASSWORD/g"
     "s/(APP_URL=)(.*)/\1http:\/\/$PROJECTNAME.$TLD/g"

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ This will `laravel new superApplication`, change into that directory, make an in
 - Replace the `.env` `APP_URL` with `$PROJECTNAME.$YOURVALETTLD`
 - Open `$PROJECTNAME.$YOURVALETTLD` in your browser
 
+Note that, in case your `$PROJECTNAME` has dashes (`-`) in it, they will be replaced with underscores (`_`) in the database name.
+
 There are also a few optional behaviors based on the parameters you pass (or define in your config file).
 
 ### Optional Arguments
@@ -112,24 +114,43 @@ There are also a few optional behaviors based on the parameters you pass (or def
   ```bash
   lambo superApplication --secure
   ```
-  
- - `--vue` to set the frontend to the default Laravel 5.* scaffolding (set by default)
 
-    ```bash
-    lambo superApplication --vue
-    ```
-  
- - `--bootstrap` to set the frontend to Bootstrap
+- `--create-db` create a new MySql database which has the same name as your project.
+  This requires `mysql` command to be available on your system.
 
-    ```bash
-    lambo superApplication --bootstrap
-    ```
-  
- - `--react` to set the frontend to React
+  ```bash
+  lambo superApplication --create-db
+  ```
 
-    ```bash
-    lambo superApplication --react
-    ```
+- `--dbuser` specify the database username.
+
+  ```bash
+  lambo superApplication --dbuser USER
+  ```
+
+- `--dbpassword` specify the database password.
+
+  ```bash
+  lambo superApplication --dbpassword SECRET
+  ```
+
+- `--vue` to set the frontend to the default Laravel 5.* scaffolding (set by default)
+
+  ```bash
+  lambo superApplication --vue
+  ```
+  
+- `--bootstrap` to set the frontend to Bootstrap
+
+  ```bash
+  lambo superApplication --bootstrap
+  ```
+  
+- `--react` to set the frontend to React
+
+  ```bash
+  lambo superApplication --react
+  ```
 
 ### Commands
 
@@ -157,12 +178,18 @@ There are also a few optional behaviors based on the parameters you pass (or def
   lambo edit-after
   ```
 
-### Config
+### Config File
 
 You can create a config file at `~/.lambo/config` rather than pass the same arguments each time you create a new project.
 
 ```bash
 lambo make-config
+```
+
+If you wish to edit your config file later on you can always use the edit command:
+
+```bash
+lambo edit-config
 ```
 
 ### After File
@@ -193,10 +220,11 @@ You also have access to variables from your config file such as `$PROJECTPATH` a
 
 ## Requirements
 
-- Mac or Ubuntu.
+- Mac or Linux.
+- [Git](https://git-scm.com).
 - Requires the [Laravel installer](https://laravel.com/docs/installation#installing-laravel) and [Laravel Valet](https://laravel.com/docs/valet) to be globally installed.
 
-> An Ubuntu fork of Valet can be find [here](https://github.com/cpriego/valet-ubuntu)
+> A Linux fork of Valet can be found [here](https://github.com/cpriego/valet-linux)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Same as #54 but added command line flag + updated readme file

Changes
===
 - `--create-db` flag to create new mysql db for the project.
 - Database name now always replaces dashes (`-`) with underscores (`_`). Even if the database is created manually this still applies.
 - documented three flags in readme: `create-db`, `dbuser`, and `dbpassword`.
 - added a 'figlet' to the help message for extra swag