### PR TITLE
Implement make-config and edit-config.

### DIFF
--- a/app/Actions/CreateOrEditConfig.php
+++ b/app/Actions/CreateOrEditConfig.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Support\Facades\File;
+
+class CreateOrEditConfig
+{
+    public function __invoke()
+    {
+        $configPath = config('home_dir') . '/.lambo';
+        $configFilePath = "{$configPath}/config";
+
+        if (File::exists($configFilePath)) {
+            app('console')->info("Opening existing config file: {$configFilePath}");
+            $this->editConfig($configFilePath);
+            return 0;
+        }
+
+        if (!File::exists($configPath)) {
+            File::makeDirectory($configPath);
+        }
+
+        File::put("$configFilePath", $this->configFileTemplate());
+        app('console')->info("Opening new config file {$configFilePath}");
+        $this->editConfig($configFilePath);
+    }
+
+    public function isMac()
+    {
+        return PHP_OS === 'Darwin';
+    }
+
+    public function editor()
+    {
+        return app('console')->option('editor');
+    }
+
+    protected function editConfig(string $configFilePath)
+    {
+        if (!$this->isMac()) {
+            exec("xdg-open {$configFilePath}");
+            return;
+        }
+
+        if ($this->editor()) {
+            exec(sprintf('"%s" "%s"',
+                $this->editor(),
+                $configFilePath
+            ));
+            return;
+        }
+
+        exec("open {$configFilePath}");
+    }
+
+    private function configFileTemplate(): string
+    {
+        return <<<'CONTENTS'
+PROJECTPATH="."
+MESSAGE="Initial commit."
+QUIET=false
+DEVELOP=false
+AUTH=false
+NODE=false
+CODEEDITOR=""
+BROWSER=""
+LINK=false
+SECURE=false
+FRONTEND="vue"
+CREATE_DATABASE=false
+DB_USERNAME="root"
+DB_PASSWORD=""
+CONTENTS;
+    }
+}

--- a/app/Actions/CreateOrEditConfig.php
+++ b/app/Actions/CreateOrEditConfig.php
@@ -50,7 +50,6 @@ class CreateOrEditConfig
             ));
             return;
         }
-
         exec("open {$configFilePath}");
     }
 

--- a/app/Actions/CreateOrEditConfig.php
+++ b/app/Actions/CreateOrEditConfig.php
@@ -9,7 +9,7 @@ class CreateOrEditConfig
     public function __invoke()
     {
         $configPath = config('home_dir') . '/.lambo';
-        $configFilePath = "{$configPath}/config";
+        $configFilePath = "{$configPath}/config.json";
 
         if (File::exists($configFilePath)) {
             app('console')->info("Opening existing config file: {$configFilePath}");
@@ -56,20 +56,22 @@ class CreateOrEditConfig
     private function configFileTemplate(): string
     {
         return <<<'CONTENTS'
-PROJECTPATH="."
-MESSAGE="Initial commit."
-QUIET=false
-DEVELOP=false
-AUTH=false
-NODE=false
-CODEEDITOR=""
-BROWSER=""
-LINK=false
-SECURE=false
-FRONTEND="vue"
-CREATE_DATABASE=false
-DB_USERNAME="root"
-DB_PASSWORD=""
+{
+    "path": ".",
+    "commit_message": "Initial commit.",
+    "quiet": false,
+    "develop": false,
+    "auth": false,
+    "node": false,
+    "codeeditor": "",
+    "browser": "",
+    "link": false,
+    "secure": false,
+    "frontend": "vue",
+    "create_database": false,
+    "db_username": "root",
+    "db_password": ""
+}
 CONTENTS;
     }
 }

--- a/app/Actions/CustomizeDotEnv.php
+++ b/app/Actions/CustomizeDotEnv.php
@@ -42,8 +42,8 @@ class CustomizeDotEnv
             'APP_NAME' => config('lambo.store.project_name'),
             'APP_URL' => config('lambo.store.project_url'),
             'DB_DATABASE' => $this->databaseName(),
-            'DB_USERNAME' => 'root',
-            'DB_PASSWORD' => null,
+            'DB_USERNAME' => config('lambo.store.database_username'),
+            'DB_PASSWORD' => config('lambo.store.database_password'),
         ];
 
         return Arr::get($replacements, $key, $fallback);

--- a/app/Commands/EditConfig.php
+++ b/app/Commands/EditConfig.php
@@ -2,16 +2,20 @@
 
 namespace App\Commands;
 
+use App\Actions\CreateOrEditConfig;
 use LaravelZero\Framework\Commands\Command;
 
 class EditConfig extends Command
 {
-    protected $signature = 'edit-config';
+    protected $signature = 'edit-config {--editor= : Open the config file in the specified <info>EDITOR</info> or the system default if none is specified.}';
 
-    protected $description = 'Edit Config File';
+    protected $description = 'Edit Config File. A new config file is created if one does not already exist.';
 
     public function handle()
     {
-        // @todo
+        app()->bind('console', function () {
+            return $this;
+        });
+        app(CreateOrEditConfig::class)();
     }
 }

--- a/app/Commands/MakeConfig.php
+++ b/app/Commands/MakeConfig.php
@@ -2,16 +2,20 @@
 
 namespace App\Commands;
 
+use App\Actions\CreateOrEditConfig;
 use LaravelZero\Framework\Commands\Command;
 
 class MakeConfig extends Command
 {
-    protected $signature = 'make-config';
+    protected $signature = 'make-config {--editor= : Open the config file in the specified <info>EDITOR</info> or the system default if none is specified.}';
 
     protected $description = 'Make Config File';
 
     public function handle()
     {
-        // @todo
+        app()->bind('console', function () {
+            return $this;
+        });
+        app(CreateOrEditConfig::class)();
     }
 }

--- a/app/Options.php
+++ b/app/Options.php
@@ -42,7 +42,7 @@ class Options
         ],
         [
             'long' => 'dbpassword',
-            'param_description' => ' PASSWORD',
+            'param_description' => 'PASSWORD',
             'cli_description' => "Specify the database password",
         ],
         [
@@ -71,7 +71,7 @@ class Options
             'cli_description' => "Scaffold the routes and views for basic Laravel auth",
         ],
         [
-            'short' => 'n',
+            'short' => 'N',
             'long' => 'node',
             'cli_description' => "Run <info>'npm install'</info> after creating the project",
         ],

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel-zero/framework": "^6.0"
+        "laravel-zero/framework": "^6.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
@@ -45,5 +46,7 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "bin": ["lambo"]
+    "bin": [
+        "lambo"
+    ]
 }


### PR DESCRIPTION
Implement make-config and edit-config.

### Pre-amble and Assumptions
- I'm following as closely as possible the patterns established with the existing code. It's possible there are instances where a simpler implementation could be used but I decided to favour existing convention. I figured that as I can't predict how you will think about my code, the safer option is to use existing precedence.
- Thinking in a fail-fast-ish way, I decided to make the pull request even though it is functionally incomplete so that you can check progress and give feedback—I don't want to go too far down the rabbit hole for no reason.  Specifically, the creating/editing of the config file is finished but the reading of the config is not implemented yet. 
- I have tried to stay close to the shell based implementation of lambo but there there is one small difference. `make-config` and `edit-config` are just aliases of the same command that takes care of all the logic. I thought about just providing the one command but decided to keep the command-line experience the same.
- I thought about more complicated features, for example an interactive wizard-like option when creating the initial config. In the end I decided to replicate existing functionality because: 1. That's what you did on stream. 2. It's probably quicker this way to get the php implementation released. Once stable and released, new fangled things can be considered.

### The $EDITOR Environment Variable
During my implementation I looked into using the $EDITOR command-line variable from within php but I came across several problems. 

In order to access the variable from within php I needed to edit my php.ini as the environment variables are not available by default. Even then, $EDITOR was not configured on my system. 

When I set `EDITOR=vim` in my shell environment and tried to open it via exec in php I received an error saying vim was not operating within a shell environment. It was basically unusable.

I decided attempting to use the shell editor was a non-starter. Even if it is set to sublime or vs code and would open properly the user would still need to mess about with php.ini.

TL;DR -- using the Mac 'open' utility, even with no application specified opens the config file in TextEdit. 