### PR TITLE
Windows home path fix

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,8 +13,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if (function_exists('posix_getuid')) {
+            // Mac or Linux
+            $path = posix_getpwuid(posix_getuid())['dir'];
+        } else {
+            // Windows
+            $path = exec('echo %USERPROFILE%');
+        }
+
         config()->set([
-            'home_dir' => posix_getpwuid(posix_getuid())['dir'],
+            'home_dir' => $path,
         ]);
     }
 
@@ -25,5 +33,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        //
     }
 }


### PR DESCRIPTION
I've been following along and am hoping to get the final product to work on windows. So far the only thing that needed to be changed is the method of getting the users home path.

The function used to get the path on mac is not defined in the windows builds. But using exec and getting the user profile path is basically the windows equivalent. 

I do not have a Mac to ensure it does not introduce any regressions, but I cannot see how it could. 

Please let me know if there is any changes you would like to see before merging. I am loving the rebuild process/streams, thanks 👍🙂 