### PR TITLE
Avoids global dependencies issues

### DIFF
--- a/box.json
+++ b/box.json
@@ -9,6 +9,7 @@
     "files": [
         "composer.json"
     ],
+    "exclude-dev-files": false,
     "exclude-composer-files": false,
     "compression": "GZ",
     "compactors": [

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel-zero/framework": "^6.0",
-        "laravel/installer": ">=3.0.1"
+        "laravel/installer": "^3.0.1"
     },
     "require-dev": {
+        "laravel-zero/framework": "^6.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.0"
     },
@@ -46,5 +46,5 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "bin": ["lambo"]
+    "bin": ["builds/lambo"]
 }


### PR DESCRIPTION
This pull request removes the `laravel-zero/framework` from the `dependencies` of Lambo to avoid conflicts with other global dependencies. Note that, once merged, before release a new version, we need to update the binary running `./lambo app:build`. https://laravel-zero.com/docs/build-a-standalone-application

Try it out, and let me know if you have any questions.