### PR TITLE
fix docs exlanation for starting new project: remove word `new`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Make sure `~/.composer/vendor/bin` is in your terminal's path.
 
 ```bash
 cd ~/Sites
-lambo new superApplication
+lambo superApplication
 ```
 
 ### What exactly does it do?


### PR DESCRIPTION
Running `lambo new superApplication` creates a new project in the folder 'new'. This fixes the docs incorrect explanation for that.